### PR TITLE
Backend feature issue 13 alerts

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -6,21 +6,21 @@ This is the entry point for the Water Quality monitoring API - it registers all 
 """
 
 from flask import Flask
-from routes.sites import sites_bp
+#from routes.sites import sites_bp
 from routes.latest import latest_bp
-from routes.summary import summary_bp
-from routes.timeseries import timeseries_bp
-from routes.alerts import alerts_bp
-from routes.export import export_bp
+#from routes.summary import summary_bp
+#from routes.timeseries import timeseries_bp
+#from routes.alerts import alerts_bp
+#from routes.export import export_bp
 
 app = Flask(__name__)
 
-app.register_blueprint(sites_bp)
+#app.register_blueprint(sites_bp)
 app.register_blueprint(latest_bp)
-app.register_blueprint(summary_bp)
-app.register_blueprint(timeseries_bp)
-app.register_blueprint(alerts_bp)
-app.register_blueprint(export_bp)
+#app.register_blueprint(summary_bp)
+#app.register_blueprint(timeseries_bp)
+#app.register_blueprint(alerts_bp)
+#app.register_blueprint(export_bp)
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,26 +1,29 @@
 """
 app.py
 
-This is the entry point for the Water Quality monitoring API - it registers all route blueprints and starts the flask development server
+This is the entry point for the Water Quality monitoring API - it
+registers all route blueprints and starts the flask development server
 
 """
 
 from flask import Flask
-#from routes.sites import sites_bp
+
+from routes.sites import sites_bp
 from routes.latest import latest_bp
-#from routes.summary import summary_bp
-#from routes.timeseries import timeseries_bp
-#from routes.alerts import alerts_bp
-#from routes.export import export_bp
+
+from routes.summary import summary_bp
+from routes.timeseries import timeseries_bp
+from routes.alerts import alerts_bp
+from routes.export import export_bp
 
 app = Flask(__name__)
 
-#app.register_blueprint(sites_bp)
+app.register_blueprint(sites_bp)
 app.register_blueprint(latest_bp)
-#app.register_blueprint(summary_bp)
-#app.register_blueprint(timeseries_bp)
-#app.register_blueprint(alerts_bp)
-#app.register_blueprint(export_bp)
+app.register_blueprint(summary_bp)
+app.register_blueprint(timeseries_bp)
+app.register_blueprint(alerts_bp)
+app.register_blueprint(export_bp)
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/backend/config.py
+++ b/backend/config.py
@@ -77,6 +77,13 @@ WX_RH_MAX = 100
 WX_RAIN_MIN = 0
 WX_RAIN_MAX = 401
 
+# water quality thresholds based on SANS 241:2015
+
+PH_CRITICAL_MIN = 6.0
+PH_CRITICAL_MAX = 9.0
+
+CONDUCTIVITY_CRITICAL_LIMIT = 1500
+
 # Alert configuration
 # Lebo Xhosa's acceptance criteria: alert triggers when reading deviates
 # by more than 20% from the 24hr average

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -6,7 +6,7 @@ Defines the database tables used in the water quality monitoring backend
 This file contains:
 - Site: stores information about each monitoring location
 - WaterReading: stores timestamped sensor readings for each site
-- Alert: stores warning or critical alerts linked to a site
+- Alert: stores warning or critical alerts linked to a site and reading
 """
 
 from sqlalchemy import Boolean, Column, DateTime
@@ -92,12 +92,14 @@ class Alert(Base):
     source_reading_id = Column(
         Integer,
         ForeignKey("water_readings.id"),
-        nullable=True,
+        nullable=False,
         index=True,
     )
 
     alert_type = Column(String, nullable=False)
     severity = Column(String, nullable=False)
+
+    message = Column(String, nullable=False)
 
     started_at = Column(DateTime, nullable=False, index=True)
     ended_at = Column(DateTime, nullable=True)  # none = still active

--- a/backend/routes/alerts.py
+++ b/backend/routes/alerts.py
@@ -1,0 +1,141 @@
+"""
+alerts.py
+
+Route for returning alert events from the database
+
+Personas:
+    - George Weah: Needs structured alert data (site, timestamp, severity)
+      to monitor contamination risks across locations
+    - Lebo Xhosa: Needs simple nd readable messages to quickly understand
+      whether water is safe
+
+"""
+
+from datetime import datetime
+from flask import Blueprint, jsonify, request
+from database.database import SessionLocal
+from database.models import Alert, Site
+
+
+alerts_bp = Blueprint("alerts", __name__)
+
+
+def parse_date(date_text):
+    """Convert ISO date text into a datetime object."""
+
+    if not date_text:
+        return None
+    try:
+        return datetime.fromisoformat(date_text)
+    except ValueError:
+        return "invalid"
+
+
+def get_alert_value_and_unit(alert):
+    """Return the sensor value and unit linked to this alert"""
+
+    reading = alert.source_reading
+
+    if reading is None:
+        return None, None
+
+    if alert.alert_type == "turbidity":
+        return reading.turbidity_ntu, "NTU"
+
+    if alert.alert_type == "ph":
+        return reading.ph, "pH"
+
+    if alert.alert_type == "conductivity":
+        return reading.conductivity_uS_cm, "µS/cm"
+
+    return None, None
+
+
+@alerts_bp.route("/alerts", methods=["GET"])
+def get_alerts():
+    """
+    Return alert events with optional site, severity and date filters
+
+    Query parameters:
+    - site_code (optional): Filters alerts to a specific monitoring site
+    - severity (optional): Filters alerts by severity ('warning' or 'critical')
+    - start (optional): Start date (ISO format YYYY-MM-DD)
+    - end (optional): End date not inclusive (ISO format YYYY-MM-DD)
+
+    Returns:
+    - List of alert objects containing:
+        site_code: identifier of the site
+        site_name: human-readable site name
+        timestamp: when the alert occurred
+        alert_type: type of issue (e.g. turbidity, ph)
+        severity: warning or critical
+        message: one-sentence explanation (Lebo persona)
+        value: sensor reading that triggered the alert
+        unit: unit of measurement
+    """
+
+    site_code = request.args.get("site_code")
+    severity = request.args.get("severity")
+    start = request.args.get("start")
+    end = request.args.get("end")
+
+    db = SessionLocal()
+
+    try:
+        query = db.query(Alert).join(Site)
+
+        if site_code:
+            # check site exists
+            site = db.query(Site).filter(Site.site_code == site_code).first()
+
+            if site is None:
+                return jsonify({"error": "Invalid site_code"}), 400
+
+            query = query.filter(Alert.site_id == site.id)
+
+        if severity:
+            if severity not in ["warning", "critical"]:
+                return jsonify({"error": "Invalid severity"}), 400
+
+            query = query.filter(Alert.severity == severity)
+
+        start_date = parse_date(start)
+        end_date = parse_date(end)
+
+        if start_date == "invalid":
+            return jsonify({"error": "Invalid start date"}), 400
+
+        if end_date == "invalid":
+            return jsonify({"error": "Invalid end date"}), 400
+
+        if start_date:
+            query = query.filter(Alert.started_at >= start_date)
+
+        if end_date:
+            query = query.filter(Alert.started_at <= end_date)
+
+        alerts = query.order_by(Alert.started_at.desc()).all()
+
+        response = []
+
+        for alert in alerts:
+            value, unit = get_alert_value_and_unit(alert)
+
+            response.append(
+                {
+                    "site_code": alert.site.site_code,
+                    "site_name": alert.site.name,
+                    "timestamp": alert.started_at.isoformat(),
+                    "alert_type": alert.alert_type,
+                    "severity": alert.severity,
+                    "message": alert.message,
+                    "value": value,
+                    "unit": unit,
+                    "source_reading_id": alert.source_reading_id,
+                }
+            )
+
+        return jsonify(response), 200
+
+    finally:
+        db.close()

--- a/backend/routes/latest.py
+++ b/backend/routes/latest.py
@@ -39,7 +39,7 @@ def get_latest():
         site = db.query(Site).filter(Site.site_code == site_code).first()
 
         if site is None:
-            return jsonify({"error": f"Invalid site_code: {site_code}"}), 404
+            return jsonify({"error": f"Invalid site_code: {site_code}"}), 400
 
         # return last readings for that site code or error if nothing
         reading = (

--- a/backend/routes/latest.py
+++ b/backend/routes/latest.py
@@ -1,0 +1,71 @@
+"""
+latest.py
+
+Route for returning the most recent water quality reading for a site.
+
+Persona:
+    - Lebo Xhosa: Needs immediate status without complex data
+"""
+
+from flask import Blueprint, jsonify, request
+
+from database.database import SessionLocal
+from database.models import Site, WaterReading
+
+latest_bp = Blueprint("latest", __name__)
+
+@latest_bp.route("/latest", methods=["GET"])
+def get_latest():
+    """
+    GET /latest?site_code=...
+
+    Query Paramameters:
+        site_code (str): id name of site
+
+    Returns:
+        JSON containing latest reading + status information
+    """
+    site_code = request.args.get("site_code")
+
+    # get the site code from the query parameters
+    if not site_code:
+        return jsonify({"error": "site_code is required"}), 400
+
+    db = SessionLocal()
+
+    try:
+        # look up site code and check it exists
+        site = db.query(Site).filter(Site.site_code == site_code).first()
+
+        if site is None:
+            return jsonify({"error": f"Invalid site_code: {site_code}"}), 404
+
+        # return last readings for that site code or error if nothing
+        reading = (
+            db.query(WaterReading)
+            .filter(WaterReading.site_id == site.id)
+            .order_by(WaterReading.recorded_at.desc())
+            .first()
+        )
+
+        if reading is None:
+            return jsonify({"error": f"No readings found for {site_code}"}), 404
+
+        # json response
+        return jsonify({
+            "site_id": site.id,
+            "site_code": site.site_code,
+            "recorded_at": reading.recorded_at.isoformat(),
+            "ph": reading.ph,
+            "turbidity_ntu": reading.turbidity_ntu,
+            "conductivity_uS_cm": reading.conductivity_uS_cm,
+            "water_temperature_c": reading.water_temperature_c,
+            "water_level_cm": reading.water_level_cm,
+            "status": reading.status,
+            "alert_triggered": reading.alert_triggered,
+            "sensor_fault": reading.sensor_fault,
+            "fault_reason": reading.fault_reason,
+        }), 200
+
+    finally:
+        db.close()

--- a/backend/routes/latest.py
+++ b/backend/routes/latest.py
@@ -56,7 +56,6 @@ def get_latest():
         return (
             jsonify(
                 {
-                    "site_id": site.id,
                     "site_code": site.site_code,
                     "name": site.name,
                     "description": site.description,

--- a/backend/routes/latest.py
+++ b/backend/routes/latest.py
@@ -14,10 +14,11 @@ from database.models import Site, WaterReading
 
 latest_bp = Blueprint("latest", __name__)
 
+
 @latest_bp.route("/latest", methods=["GET"])
 def get_latest():
     """
-    GET /latest?site_code=...
+    GET /latest?site_code= ...
 
     Query Paramameters:
         site_code (str): id name of site
@@ -49,23 +50,28 @@ def get_latest():
         )
 
         if reading is None:
-            return jsonify({"error": f"No readings found for {site_code}"}), 404
+            return jsonify({"error": f"No readings for {site_code}"}), 404
 
         # json response
-        return jsonify({
-            "site_id": site.id,
-            "site_code": site.site_code,
-            "recorded_at": reading.recorded_at.isoformat(),
-            "ph": reading.ph,
-            "turbidity_ntu": reading.turbidity_ntu,
-            "conductivity_uS_cm": reading.conductivity_uS_cm,
-            "water_temperature_c": reading.water_temperature_c,
-            "water_level_cm": reading.water_level_cm,
-            "status": reading.status,
-            "alert_triggered": reading.alert_triggered,
-            "sensor_fault": reading.sensor_fault,
-            "fault_reason": reading.fault_reason,
-        }), 200
+        return (
+            jsonify(
+                {
+                    "site_id": site.id,
+                    "site_code": site.site_code,
+                    "recorded_at": reading.recorded_at.isoformat(),
+                    "ph": reading.ph,
+                    "turbidity_ntu": reading.turbidity_ntu,
+                    "conductivity_uS_cm": reading.conductivity_uS_cm,
+                    "water_temperature_c": reading.water_temperature_c,
+                    "water_level_cm": reading.water_level_cm,
+                    "status": reading.status,
+                    "alert_triggered": reading.alert_triggered,
+                    "sensor_fault": reading.sensor_fault,
+                    "fault_reason": reading.fault_reason,
+                }
+            ),
+            200,
+        )
 
     finally:
         db.close()

--- a/backend/routes/latest.py
+++ b/backend/routes/latest.py
@@ -58,6 +58,8 @@ def get_latest():
                 {
                     "site_id": site.id,
                     "site_code": site.site_code,
+                    "name": site.name,
+                    "description": site.description,
                     "recorded_at": reading.recorded_at.isoformat(),
                     "ph": reading.ph,
                     "turbidity_ntu": reading.turbidity_ntu,

--- a/backend/scripts/import_water.py
+++ b/backend/scripts/import_water.py
@@ -23,6 +23,7 @@ from validation.import_validators import (
     check_alert_flag,
     validate_row,
 )
+from services.alert_service import create_alert_events_for_reading
 
 
 def get_or_create_site(db, site_code, name, description, latitude, longitude):
@@ -243,6 +244,16 @@ def main():
 
             # Add this reading to the database session
             db.add(reading)
+
+            # flush gives this reading an ID before the full commit which
+            # is needed because alert_events.source_reading_id links to
+            # reading.id
+            db.flush()
+
+            # create linked alert event rows if this reading triggered an alert
+            # or failed validation.
+            if reading.alert_triggered or reading.sensor_fault:
+                create_alert_events_for_reading(db, reading)
 
             # commits every 1000 rows so memory does not grow too much
             if index % 1000 == 0:

--- a/backend/services/alert_service.py
+++ b/backend/services/alert_service.py
@@ -1,0 +1,145 @@
+"""
+alert_service.py
+
+Contains the logic for creating alert records from water readings
+"""
+
+from database.models import Alert
+
+from config import (
+    PH_CRITICAL_MIN,
+    PH_CRITICAL_MAX,
+    CONDUCTIVITY_CRITICAL_LIMIT,
+)
+
+
+def get_ph_severity(ph):
+    """Return severtiy for pH alert based on SANS 241 thresholds."""
+
+    if ph is not None and (ph < PH_CRITICAL_MIN or ph > PH_CRITICAL_MAX):
+        return "critical"
+
+    return "warning"
+
+
+def get_conductivity_severity(conductivity):
+    """Return severity for conductivity alert based on thresholds."""
+
+    if conductivity is not None and conductivity > CONDUCTIVITY_CRITICAL_LIMIT:
+        return "critical"
+
+    return "warning"
+
+
+def create_alert_events_for_reading(db, reading):
+    """Create alert records for any alerts triggered by a reading.
+
+    Args:
+        db: Active database
+        reading: WaterReading object
+    """
+
+    alerts = []
+
+    # turbidity already has separate warning and critical flags in the dataset
+    # alert_turbidity = turbidity > 5 NTU
+    # alert_turbidity_crit = turbidity > 10 NTU
+    # so we can use these directly instead of recalculating thresholds
+
+    # check critical first to avoid duplicate alerts
+    if reading.alert_turbidity_crit:
+        alerts.append(
+            {
+                "alert_type": "turbidity",
+                "severity": "critical",
+                "message": (
+                    "Critical turbidity detected. Water is very "
+                    "cloudy and may be unsafe for drinking or cleaning. "
+                    "Avoid using this water."
+                ),
+            }
+        )
+
+    elif reading.alert_turbidity:
+        alerts.append(
+            {
+                "alert_type": "turbidity",
+                "severity": "warning",
+                "message": (
+                    "Turbidity is above recommended levels. Water may be "
+                    "cloudy and less safe for drinking or cleaning. "
+                    "Treat or boil before use."
+                ),
+            }
+        )
+
+    # alert_ph only tells us if somethings, so we calculate severity
+    if reading.alert_ph:
+        severity = get_ph_severity(reading.ph)
+
+        if severity == "critical":
+            message = (
+                "Critical pH level detected. Water may be unsafe for "
+                "drinking and could irritate skin during cleaning. "
+                "Avoid using this water."
+            )
+        else:
+            message = (
+                "pH is outside the recommended range. Water quality may "
+                "be affected for drinking and cleaning. Use with caution."
+            )
+
+        alerts.append(
+            {
+                "alert_type": "ph",
+                "severity": severity,
+                "message": message,
+            }
+        )
+
+    # conductivity
+    if reading.alert_conductivity:
+        severity = get_conductivity_severity(reading.conductivity_uS_cm)
+
+        if severity == "critical":
+            message = (
+                "Critical conductivity detected. This may indicate "
+                "contamination or high salt levels. Avoid using this water."
+            )
+        else:
+            message = (
+                "Conductivity is above recommended levels. This may indicate "
+                "increased salts or runoff. Use with caution."
+            )
+
+        alerts.append(
+            {
+                "alert_type": "conductivity",
+                "severity": severity,
+                "message": message,
+            }
+        )
+
+    # sensor fault comes from validation, not original dataset rules
+    if reading.sensor_fault:
+        alerts.append(
+            {
+                "alert_type": "sensor_fault",
+                "severity": "warning",
+                "message": reading.fault_reason or "Sensor fault detected.",
+            }
+        )
+
+    # save to database w/ each alert becomes its own row in alert_events table
+    for alert in alerts:
+        db.add(
+            Alert(
+                site_id=reading.site_id,
+                source_reading_id=reading.id,
+                alert_type=alert["alert_type"],
+                severity=alert["severity"],
+                message=alert["message"],
+                started_at=reading.recorded_at,
+                ended_at=None,  # not tracking durations in MVP
+            )
+        )


### PR DESCRIPTION
Firstly added the functionality to the 'alert_events' table in the database. This stores alerts sepearately from water readings, which allows severity of events to be filtered as well as clearer tracking of issues across different sites. Some alert generation logic was implemented whicg was based on SANS 241 thresholds

Also added a GET /alerts endpoint to return user friendly alert data, with support for filtering by site, severity, and date range.

A GET /alerts endpoint was created to return user-friendly alert data, with support for filtering by site, severity, and date range. This supports both George Weah's persona (monitoring and prioritising risks) and Lebo's persona (simple one sentence explanations of why water is unsafe). The endpoint was tested with different filters and error cases to ensure correct behaviour.

e.g.

<img width="940" height="244" alt="image" src="https://github.com/user-attachments/assets/52002efa-0d61-4ccc-8894-477132b97985" />

testing time filter


<img width="940" height="253" alt="image" src="https://github.com/user-attachments/assets/2792fcd1-6bfd-4122-8b03-e5cd4ac2f93d" />

testing an invalid severity