### PR TITLE
Backend feature issue 16 export csv

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -86,7 +86,7 @@ ALERT_DEVIATION_THRESHOLD = 0.2
 # site IDs and measurement values
 EXPORT_COLUMNS = [
     "timestamp",
-    "site_id",
+    "site_code",
     "ph",
     "turbidity_ntu",
     "conductivity_uS_cm",

--- a/backend/routes/export.py
+++ b/backend/routes/export.py
@@ -1,0 +1,103 @@
+"""
+export.py
+
+Provides the endpoint to be able to download filtered water quality
+as a CSV file with /GET export
+
+Filters are:
+    - monitoring site (site_id)
+    - start date
+    - end date
+
+Persona Coverage:
+    - Jack Wilshere: a reseacher who needs to download raw filtered
+    site analysis data for offline analysis. This lets him have a clean
+    CSV file with data he can upload to external data analysis tools 
+    rather than having to copy and paste readings from the dashboard
+
+"""
+
+from config import EXPORT_COLUMNS
+from flask import Blueprint, Response, jsonify, request
+
+import csv
+from io import StringIO
+from datetime import datetime
+from database.database import SessionLocal
+from database.models import Site, WaterReading
+
+export_bp = Blueprint("export", __name__)
+
+@export_bp.route("/export", methods=["GET"])
+def export_csv():
+    """
+
+    query params:
+        - site_code (required):  'site_upstream', site_downstream',
+        'site_resovoir'
+        - start (optional): YYYY-MM-DD
+        - end (optional): YYYY-MM-DD
+
+    """
+
+    site_code = request.args.get("site_code")
+    start = request.args.get("start")
+    end = request.args.get("end")
+
+    if not site_code:
+        return jsonify({"error": "site_code is required"}), 400
+
+    db = SessionLocal()
+
+    try:
+        # query by the site_code first
+        query = (
+            db.query(WaterReading)
+            .join(Site)
+            .filter(Site.site_code == site_code)
+        )
+
+        # add date queries if they've been added
+        if start:
+            try:
+                start_date = datetime.strptime(start, "%Y-%m-%d")
+            except valueError:
+                return jsonify({"error": "start must be YYYY-MM-DD"}), 400
+
+            query = query.filter(WaterReading.recorded_at >= start_date)
+        
+        if end:
+            try:
+                end_date = datetime.strptime(end, "%Y-%m-%d")
+            except ValueError:
+                return jsonify({"error": "end must be YYYY-MM-DD"}), 400
+
+            query = query.filter(WaterReading.recorded_at <= end_date)
+
+        readings = query.order_by(WaterReading.recorded_at.asc()).all()
+
+        if not readings:
+            return jsonify({"error": "no data found for selected filters"}), 404
+
+
+EXPORT_COLUMNS = [
+    "timestamp",
+    "site_id",
+    "ph",
+    "turbidity_ntu",
+    "conductivity_uS_cm",
+    "water_temperature_c",
+    "water_level_cm",
+    "light_lux",
+    "status",
+    "alert_triggered",
+    "alert_ph",
+    "alert_turbidity",
+    "alert_turbidity_crit",
+    "alert_conductivity",
+    "wx_temp_c",
+    "wx_rh_pct",
+    "wx_rain_mm_hr",
+    "sensor_fault",
+    "fault_reason",
+]

--- a/backend/routes/export.py
+++ b/backend/routes/export.py
@@ -126,26 +126,3 @@ def export_csv():
 
 
 """
-EXPORT_COLUMNS = [
-    "timestamp",
-    "site_code",
-    "ph",
-    "turbidity_ntu",
-    "conductivity_uS_cm",
-    "water_temperature_c",
-    "water_level_cm",
-    "light_lux",
-    "status",
-    "alert_triggered",
-    "alert_ph",
-    "alert_turbidity",
-    "alert_turbidity_crit",
-    "alert_conductivity",
-    "wx_temp_c",
-    "wx_rh_pct",
-    "wx_rain_mm_hr",
-    "sensor_fault",
-    "fault_reason",
-]
-
-"""

--- a/backend/routes/export.py
+++ b/backend/routes/export.py
@@ -5,14 +5,14 @@ Provides the endpoint to be able to download filtered water quality
 as a CSV file with /GET export
 
 Filters are:
-    - monitoring site (site_id)
+    - monitoring site (site_code)
     - start date
     - end date
 
 Persona Coverage:
     - Jack Wilshere: a reseacher who needs to download raw filtered
     site analysis data for offline analysis. This lets him have a clean
-    CSV file with data he can upload to external data analysis tools 
+    CSV file with data he can upload to external data analysis tools
     rather than having to copy and paste readings from the dashboard
 
 """
@@ -27,6 +27,7 @@ from database.database import SessionLocal
 from database.models import Site, WaterReading
 
 export_bp = Blueprint("export", __name__)
+
 
 @export_bp.route("/export", methods=["GET"])
 def export_csv():
@@ -51,21 +52,17 @@ def export_csv():
 
     try:
         # query by the site_code first
-        query = (
-            db.query(WaterReading)
-            .join(Site)
-            .filter(Site.site_code == site_code)
-        )
+        query = db.query(WaterReading).join(Site).filter(Site.site_code == site_code)
 
         # add date queries if they've been added
         if start:
             try:
-                start_date = datetime.strptime(start, "%Y-%m-%d")
-            except valueError:
+                start_date = datetime.strptime(start, "%Y-%m-%d")  # iso format
+            except ValueError:
                 return jsonify({"error": "start must be YYYY-MM-DD"}), 400
 
             query = query.filter(WaterReading.recorded_at >= start_date)
-        
+
         if end:
             try:
                 end_date = datetime.strptime(end, "%Y-%m-%d")
@@ -79,10 +76,59 @@ def export_csv():
         if not readings:
             return jsonify({"error": "no data found for selected filters"}), 404
 
+        output = StringIO()
+        writer = csv.DictWriter(output, fieldnames=EXPORT_COLUMNS)
+        writer.writeheader()
 
+        for reading in readings:
+            row = {}
+            for column in EXPORT_COLUMNS:
+                if column == "timestamp":
+                    value = reading.recorded_at.strftime("%Y-%m-%dT%H:%M:%S")
+                elif column == "site_code":
+                    value = site_code
+                else:
+                    value = getattr(reading, column, None)
+
+                row[column] = value
+
+            writer.writerow(row)
+
+        csv_data = output.getvalue()
+        output.close()
+
+        # create custom filename based on filters (easier to recognise)
+        filename = f"water_quality_{site_code}"
+
+        if start and end:
+            filename += f"_{start}_to_{end}"
+        elif start:
+            filename += f"_from_{start}"
+        elif end:
+            filename += f"_to_{end}"
+
+        filename += ".csv"
+
+        # return the downloadable csv file
+        # disposition = download as attachment not as page
+        return Response(
+            csv_data,
+            mimetype="text/csv",
+            headers={"Content-Disposition": f"attachment; filename={filename}"},
+        )
+
+    except Exception as error:
+        print(f"Export error: {error}")
+        return jsonify({"error": "server error"}), 500
+
+    finally:
+        db.close()
+
+
+"""
 EXPORT_COLUMNS = [
     "timestamp",
-    "site_id",
+    "site_code",
     "ph",
     "turbidity_ntu",
     "conductivity_uS_cm",
@@ -101,3 +147,5 @@ EXPORT_COLUMNS = [
     "sensor_fault",
     "fault_reason",
 ]
+
+"""


### PR DESCRIPTION
Implemented a /export endpoint that lets users download filtered water quality data as a CSV file. It supports filtering by site_code and optional start or end dates, and returns the file directly as a download in the bowser.

The data is pulled from the database and converted into CSV format, with timestamps formatted consistently in ISO format. The filename is also generated based on the selected filters to make it easier to recognise.

This helps support the Jack Wilshere's researcher persona by allowing data to be easily exported for offline analysis instead of copying it manually from the dashboard. Manual testing was carried out to check filtering, error handling, and that the CSV output is correct.

e.g.

full site export of site_code = site_upstream 

<img width="940" height="188" alt="image" src="https://github.com/user-attachments/assets/195b0bcb-815f-4a30-9d55-be3e0b6d8168" />

Downloads as a CSV and with the correct name

<img width="940" height="174" alt="image" src="https://github.com/user-attachments/assets/e9a7a58e-c81a-4147-b3fc-e718fa38cef2" />

Formatted perfectly with all the information for each reading from the upstream site