### PR TITLE
Backend feature issue 23 validators

### DIFF
--- a/backend/validation/validators.py
+++ b/backend/validation/validators.py
@@ -1,0 +1,22 @@
+"""
+validators.py
+
+Input validation functions for all API endpoints.
+"""
+
+
+def validate_site_id(site_code: str | None, valid_site_codes: list) -> str | None:
+    """Validates that a site_code is present and exists in the dataset.
+
+    Args:
+        site_code: The site_code value from the request query parameters.
+        valid_site_codes: List of site_codes that exist in the database.
+
+    Returns:
+        An error message string if validation fails, or None if valid.
+    """
+    if not site_code:
+        return "site_code is required"
+    if site_code not in valid_site_codes:
+        return f"invalid site_code: {site_code}"
+    return None


### PR DESCRIPTION
Implements validate_site_id() in validation/validators.py. 
Validates that a site_code parameter is present and exists in 
the database before any query is made. Returns a descriptive 
error string if validation fails or None if valid — route 
handlers call this once and return immediately if an error 
is returned.

## Closes
Closes #23

## Persona served
- Lebo Xhosa: clear error messages prevent confusion for a 
  non-tech-native user when invalid inputs are submitted
- Jack Wilshere: validation ensures filters produce meaningful 
  results rather than silently returning wrong data
- George Weah: fast early rejection of bad inputs means no time 
  wasted waiting for a query to fail under time pressure

## Changes made
- Added validate_site_id() to validation/validators.py
- Returns descriptive error string on failure or None if valid
- Follows snake_case naming conventions
- Google-style docstring

## How I tested it
- Tested via GET /summary endpoint — missing site_code returns 
  "site_code is required" with 400
- Invalid site_code returns "invalid site_code: fake_site" with 400
- Valid site_code passes validation and returns data correctly
- Pre-commit hooks passing — Black and Flake8 both clean