### PR TITLE
Backend feature issue 8 get/summary

### DIFF
--- a/backend/routes/summary.py
+++ b/backend/routes/summary.py
@@ -1,0 +1,89 @@
+"""
+routes/summary.py
+
+Defines the GET /summary endpoint.
+Returns the latest core water quality metrics for a site.
+
+Returns a simplified subset of the latest reading — only the fields
+needed for Lebo's binary dashboard. Weather columns, fault columns,
+and individual alert flags are excluded to keep the response simple
+and fast to parse on a low bandwidth connection.
+
+Persona coverage:
+    - Lebo Xhosa: The four metric values provide the one-sentence
+      explanation when he taps a source (US-07). Simpler response than
+      /latest means less data over a poor connection.
+
+    - George Weah: secondary use — headline numbers for a site at a glance
+      before deciding whether to investigate trends in detail (US-09)
+"""
+
+from flask import Blueprint, jsonify, request
+from database.database import SessionLocal
+from database.models import Site, WaterReading
+from services.filters import get_valid_site_codes
+from validation.validators import validate_site_id
+
+summary_bp = Blueprint("summary", __name__)
+
+
+@summary_bp.route("/summary", methods=["GET"])
+def get_summary() -> tuple:
+    """
+    Rreturns the latest core water quality metrics for a site.
+
+    Returns only the four core sensor readings, status, and alert_triggered flag.
+    All other columns are omitted.
+
+    Query Parameters:
+        site_code (str): Required. The site code to query (e.g. "site_upstream").
+
+    Returns:
+        tuple: A JSON object with core metrics and HTTP 200.
+               HTTP 400 if site_id is missing or invalid.
+               HTTP 404 if no data exists for the site.
+
+    """
+
+    site_code = request.args.get("site_code")
+
+    db = SessionLocal()
+    try:
+        valid_site_codes = get_valid_site_codes(db)
+
+        error = validate_site_id(site_code, valid_site_codes)
+        if error:
+            return jsonify({"error": error}), 400
+
+        site = db.query(Site).filter(Site.site_code == site_code).first()
+        if site is None:
+            return jsonify({"error": f"invalid site_code: {site_code}"}), 400
+
+        latest = (
+            db.query(WaterReading)
+            .filter(WaterReading.site_id == site.id)
+            .order_by(WaterReading.recorded_at.desc())
+            .first()
+        )
+
+        if latest is None:
+            return jsonify({"error": f"no data found for site: {site_code}"}), 404
+
+        return (
+            jsonify(
+                {
+                    "site_code": site_code,
+                    "recorded_at": latest.recorded_at.isoformat(),
+                    "ph": latest.ph,
+                    "turbidity_ntu": latest.turbidity_ntu,
+                    "conductivity_uS_cm": latest.conductivity_uS_cm,
+                    "water_temperature_c": latest.water_temperature_c,
+                    "status": latest.status,
+                    "alert_triggered": latest.alert_triggered,
+                }
+            ),
+            200,
+        )
+
+    finally:
+        db.close()

--- a/backend/tests/test_summary.py
+++ b/backend/tests/test_summary.py
@@ -1,0 +1,169 @@
+"""
+test_summary.py
+
+Unit tests for GET /summary endpoint.
+Tests that the endpoint returns the latest core water quality metrics
+for a site in a simplified low-bandwidth response.
+
+Persona coverage:
+    - Lebo Xhosa: summary endpoint is specifically designed for his
+      low bandwidth connection — tests verify only essential fields
+      are returned and response is correct
+"""
+
+import pytest
+from datetime import datetime
+
+from app import app
+from database.database import Base, SessionLocal, engine
+from database.models import Site, WaterReading
+
+
+@pytest.fixture
+def client():
+    """Creates a test Flask client with a fresh test database."""
+    app.config["TESTING"] = True
+    Base.metadata.create_all(bind=engine)
+
+    db = SessionLocal()
+
+    site = Site(
+        site_code="site_test",
+        name="Test Site",
+        description="Test site for unit tests",
+        is_active=True,
+    )
+    db.add(site)
+    db.commit()
+    db.refresh(site)
+
+    older_reading = WaterReading(
+        site_id=site.id,
+        recorded_at=datetime(2023, 1, 1, 10, 0, 0),
+        ph=6.5,
+        turbidity_ntu=2.1,
+        conductivity_uS_cm=300.0,
+        water_temperature_c=17.0,
+        water_level_cm=120.0,
+        light_lux=500.0,
+        status="normal",
+        alert_triggered=False,
+        alert_ph=False,
+        alert_turbidity=False,
+        alert_turbidity_crit=False,
+        alert_conductivity=False,
+        sensor_fault=False,
+    )
+
+    latest_reading = WaterReading(
+        site_id=site.id,
+        recorded_at=datetime(2023, 6, 1, 12, 0, 0),
+        ph=7.2,
+        turbidity_ntu=3.1,
+        conductivity_uS_cm=450.0,
+        water_temperature_c=18.5,
+        water_level_cm=142.0,
+        light_lux=800.0,
+        status="normal",
+        alert_triggered=False,
+        alert_ph=False,
+        alert_turbidity=False,
+        alert_turbidity_crit=False,
+        alert_conductivity=False,
+        sensor_fault=False,
+    )
+
+    db.add(older_reading)
+    db.add(latest_reading)
+    db.commit()
+    db.close()
+
+    with app.test_client() as client:
+        yield client
+
+    Base.metadata.drop_all(bind=engine)
+
+
+def test_summary_returns_200(client):
+    """a GET /summary with valid site_code should return a HTTP 200."""
+    response = client.get("/summary?site_code=site_test")
+    assert response.status_code == 200
+
+
+def test_summary_returns_correct_site_code(client):
+    """The GET /summary should return the correct site_code in its response."""
+    response = client.get("/summary?site_code=site_test")
+    data = response.get_json()
+    assert data["site_code"] == "site_test"
+
+
+def test_summary_returns_latest_reading(client):
+    """GET /summary should return the most recent reading not an older one."""
+    response = client.get("/summary?site_code=site_test")
+    data = response.get_json()
+    assert data["ph"] == 7.2
+    assert data["turbidity_ntu"] == 3.1
+    assert data["conductivity_uS_cm"] == 450.0
+    assert data["water_temperature_c"] == 18.5
+
+
+def test_summary_returns_required_fields(client):
+    """a GET /summary should return all the required fields."""
+    response = client.get("/summary?site_code=site_test")
+    data = response.get_json()
+    required_fields = [
+        "site_code",
+        "recorded_at",
+        "ph",
+        "turbidity_ntu",
+        "conductivity_uS_cm",
+        "water_temperature_c",
+        "status",
+        "alert_triggered",
+    ]
+    for field in required_fields:
+        assert field in data, f"Missing field: {field}"
+
+
+def test_summary_excludes_weather_and_fault_fields(client):
+    """GET /summary should not include weather or fault columns.
+
+    Summary is a low bandwidth endpoint for Lebo Xhosa — only essential
+    fields should be returned to minimise data transfer on poor connections.
+    """
+    response = client.get("/summary?site_code=site_test")
+    data = response.get_json()
+    excluded_fields = [
+        "wx_temp_c",
+        "wx_rh_pct",
+        "wx_rain_mm_hr",
+        "sensor_fault",
+        "fault_reason",
+        "light_lux",
+        "water_level_cm",
+        "alert_ph",
+        "alert_turbidity",
+        "alert_turbidity_crit",
+        "alert_conductivity",
+    ]
+    for field in excluded_fields:
+        assert field not in data, f"Field should be excluded: {field}"
+
+
+def test_summary_missing_site_code_returns_400(client):
+    """A GET /summary without a site_code should return  a HTTP 400."""
+    response = client.get("/summary")
+    assert response.status_code == 400
+
+
+def test_summary_invalid_site_code_returns_400(client):
+    """A GET /summary with an invalid site_code should return a HTTP 400."""
+    response = client.get("/summary?site_code=fake_site")
+    assert response.status_code == 400
+
+
+def test_summary_invalid_site_code_returns_error_message(client):
+    """A GET /summary with an invalid site_code should return an error thats descriptive."""
+    response = client.get("/summary?site_code=fake_site")
+    data = response.get_json()
+    assert "error" in data


### PR DESCRIPTION
Implements the GET /summary endpoint in routes/summary.py. Returns 
a minimal subset of the latest reading for a site — only the four 
core water quality metrics, status, and alert_triggered flag.

Designed specifically as a low bandwidth endpoint for Lebo Xhosa's 
poor connectivity constraint. By returning only 8 fields instead of 
the full reading, the response is significantly smaller than /latest, 
reducing data transfer for users in areas with poor cellular coverage.

Also adds tests/test_summary.py with 8 unit tests.

## Closes
Closes #7

## Persona served
- Lebo Xhosa: primary use case — low bandwidth summary endpoint 
  for his binary safe/unsafe dashboard. Returns only essential 
  fields to minimise data transfer on poor connections (US-07)
- George Weah: secondary use — headline numbers for a site at a 
  glance before deciding whether to investigate trends (US-09)

## Changes made
- Added routes/summary.py — GET /summary endpoint returning 8 
  core fields only
- Added tests/test_summary.py — 8 unit tests
- Google-style docstrings on all functions
- Type hints on all function signatures
- Follows snake_case naming conventions throughout

## Design decision
Summary intentionally excludes weather columns, fault columns, 
and individual alert flags. This is not an oversight — it is a 
deliberate design decision to serve Lebo Xhosa's low bandwidth 
constraint. /latest exists for when the full reading is needed. 
/summary exists for the dashboard homepage where only the 
status and core metrics are required.

## How I tested it

### Manual testing
- GET /summary?site_code=site_upstream → correct 8 fields returned
- GET /summary → 400 "site_code is required"
- GET /summary?site_code=fake_site → 400 "invalid site_code: fake_site"
- Confirmed response is smaller than /latest response
- Confirmed most recent reading is returned not an older one
- Pre-commit hooks passing — Black and Flake8 both clean

### Unit tests
pytest tests/test_summary.py -v — 8/8 passing