### PR TITLE
Backend feature issue 11 get timeseries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ data/water_quality.csv
 **/__pycache__
 **/*.pyc
 **/*.pyc
+backend/water_quality_sample.db

--- a/backend/app.py
+++ b/backend/app.py
@@ -9,21 +9,23 @@ registers all route blueprints and starts the flask development server
 from flask import Flask
 
 from routes.sites import sites_bp
-#from routes.latest import latest_bp
+
+# from routes.latest import latest_bp
 
 # from routes.summary import summary_bp
-#from routes.timeseries import timeseries_bp
-#from routes.alerts import alerts_bp
-#from routes.export import export_bp
+from routes.timeseries import timeseries_bp
+
+# from routes.alerts import alerts_bp
+# from routes.export import export_bp
 
 app = Flask(__name__)
 
 app.register_blueprint(sites_bp)
-#app.register_blueprint(latest_bp)
-#app.register_blueprint(summary_bp)
-#app.register_blueprint(timeseries_bp)
-#pp.register_blueprint(alerts_bp)
-#app.register_blueprint(export_bp)
+# app.register_blueprint(latest_bp)
+# app.register_blueprint(summary_bp)
+app.register_blueprint(timeseries_bp)
+# pp.register_blueprint(alerts_bp)
+# app.register_blueprint(export_bp)
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/backend/routes/timeseries.py
+++ b/backend/routes/timeseries.py
@@ -1,50 +1,83 @@
 """
 routes/timeseries.py
 
-Defines the GET /timeseries endpoing.
-Returns the aggregated water quality readings over time for a site/metric filter.
+Defines the GET /timeseries endpoint.
+Returns aggregated water quality readings over time for a site and metric.
+
+Delegates aggregation to services/aggregation.py which loads the
+filtered query into pandas for resampling. This route only handles
+HTTP concerns — extracting parameters, validating, and returning JSON.
 
 Persona coverage:
-    - Jack Wilshere: 
-        - Queries long date ranges across sites to identify patterns in the environment.
-        - Supports hourly and daily aggregation time periods, giving him the ability to choose which period is appropriate for his research
+- Jack Wilshere: primary use case — queries long date ranges to
+ identify environmental trends. Supports daily and hourly aggregation
+ so he can choose the resolution appropriate for his research (US-03)
+
+- George Weah: use case - compares current readings against historical trends to
+ determine whether a change is just a short-term fluctuation or is actually a developing
+ contamination risk (US-10)
 """
 
 from flask import Blueprint, jsonify, request
+
+from config import VALID_FREQUENCIES, VALID_METRICS
+from database.database import SessionLocal
 from services.aggregation import get_trends
-from services.data_loader import df
-from validation.validators import validate_timeseries_params
+from services.filters import get_valid_site_codes
 
 timeseries_bp = Blueprint("timeseries", __name__)
 
 
-@timeseries_bp.route(
-    "/timeseries", methods=["GET"]
-)  # defines a GET endpoint that allows for frontend to request filtered and aggregated water data
+@timeseries_bp.route("/timeseries", methods=["GET"])
 def timeseries() -> tuple:
-    """
-    timeseries() returns aggregated sensor readings over time for a site and metric.
-    - It aggregates data into hourly or daily time periods and returns the mean, minimum and maximum value per period.
+    """Returns aggregated sensor readings over time for a site and metric.
 
+    Sensor fault rows are excluded from the aggregation,
+      so that faulty readings do not skew results.
 
+    Query Parameters:
+    site_code (str): Required. The site code to query (e.g. "site_upstream").
+    metric (str): Optional. Sensor column to aggregate. Default: "ph".
+    Must be one of VALID_METRICS in config.py.
+    freq (str): Optional. Aggregation frequency. Default: "D" (daily).
+    "D" for daily, "h" for hourly.
+    start (str): Optional. Start date YYYY-MM-DD inclusive.
+    end (str): Optional. End date YYYY-MM-DD inclusive.
+
+    Returns:
+    tuple: A JSON array of aggregated readings with HTTP 200.
+    HTTP 400 if any parameter is missing or invalid.
+    HTTP 404 if no data matches the selected filters.
     """
-    site_id = request.args.get("site_id")
-    metric = request.args.get(
-        "metric", "ph"
-    )  # using ph as default if metric not specified (ph is widely understood and in every row)
-    freq = request.args.get(
-        "freq", "D"
-    )  # gets time group for aggregation, using "D"(daily) as default
+    site_code = request.args.get("site_code")
+    metric = request.args.get("metric", "ph")
+    freq = request.args.get("freq", "D")
     start = request.args.get("start")
     end = request.args.get("end")
 
-    result = get_trends(site_id, metric, freq, start, end)
-    if result.empty:
-        return jsonify({"error": "no data found for selected filters"}), 404  # handle empty result
-    result["timestamp"] = result["timestamp"].astype(
-        str
-    )  # convert datetime to string format for use with JSON
-    return (
-        jsonify(result.to_dict(orient="records")),
-        200,
-    )  # convert dataframe to list of dictionary so it can be sent to frontend as JSON
+    db = SessionLocal()
+    try:
+        valid_site_codes = get_valid_site_codes(db)
+
+        if not site_code:
+            return jsonify({"error": "site_code is required"}), 400
+
+        if site_code not in valid_site_codes:
+            return jsonify({"error": f"invalid site_code: {site_code}"}), 400
+
+        if metric not in VALID_METRICS:
+            valid = ", ".join(VALID_METRICS)
+            return jsonify({"error": f"invalid metric: {metric} — must be one of: {valid}"}), 400
+
+        if freq not in VALID_FREQUENCIES:
+            return jsonify({"error": "invalid frequency — must be 'h' or 'D'"}), 400
+
+        result = get_trends(db, site_code, metric, freq, start, end)
+        if result.empty:
+            return jsonify({"error": "no data found for selected filters"}), 404
+
+        result["recorded_at"] = result["recorded_at"].astype(str)
+        return jsonify(result.to_dict(orient="records")), 200
+
+    finally:
+        db.close()

--- a/backend/services/aggregation.py
+++ b/backend/services/aggregation.py
@@ -1,16 +1,85 @@
+"""
+aggregation.py
+
+Time series aggregation for water quality data.
+Loads filtered database query results into pandas for resampling.
+
+Persona coverage:
+    - Jack Wilshere: hourly and daily aggregation directly implements
+      his US-03 trend chart acceptance criteria.
+    - George Weah: historical trend comparison for US-10.
+"""
+
+import pandas as pd
+
+from database.models import WaterReading
+from services.filters import get_site_by_code
+
+
 def get_trends(
-    site_id, metric, freq="D", start_date=None, end_date=None
-):  # gets trends for a specific time period
-    data = filter_water_data(site_id, start_date, end_date)
+    db,
+    site_code: str,
+    metric: str,
+    freq: str = "D",
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> pd.DataFrame:
+    """Returns aggregated sensor readings over time for a site and metric.
+
+    Args:
+        db: Active SQLAlchemy database session.
+        site_code: The site identifier string (e.g. "site_upstream").
+        metric: The sensor column to aggregate (e.g. "ph", "turbidity_ntu").
+        freq: Aggregation frequency — "D" for daily, "h" for hourly.
+        start_date: Optional ISO 8601 date string — inclusive start (YYYY-MM-DD).
+        end_date: Optional ISO 8601 date string — inclusive end (YYYY-MM-DD).
+
+    Returns:
+        A DataFrame with columns: recorded_at, avg, min, max.
+        Returns an empty DataFrame if no data matches the filters.
+    """
+    site = get_site_by_code(db, site_code)
+    if site is None:
+        return pd.DataFrame()
+
+    query = db.query(WaterReading).filter(
+        WaterReading.site_id == site.id,
+        WaterReading.sensor_fault == False,  # noqa: E712
+    )
+
+    if start_date:
+        query = query.filter(WaterReading.recorded_at >= start_date)
+
+    if end_date:
+        query = query.filter(WaterReading.recorded_at <= end_date)
+
+    rows = query.order_by(WaterReading.recorded_at).all()
+
+    if not rows:
+        return pd.DataFrame()
+
+    data = pd.DataFrame(
+        [
+            {
+                "recorded_at": row.recorded_at,
+                metric: getattr(row, metric),
+            }
+            for row in rows
+        ]
+    )
+
+    data = data.dropna(subset=[metric])
 
     if data.empty:
-        return pd.DataFrame()  # return empty result if no data found
+        return pd.DataFrame()
 
     trend = (
-        data.set_index("timestamp")  # make the timestamp the index
-        .resample(freq)[metric]  # aggregates data into either 'h'(hour) or 'D'(day) time groups
-        .agg(["mean", "min", "max"])  # calculates mean, minimum and maximum
+        data.set_index("recorded_at")
+        .resample(freq)[metric]
+        .agg(["mean", "min", "max"])
+        .dropna()
         .reset_index()
+        .rename(columns={"mean": "avg"})
     )
-    trend = trend.rename(columns={"mean": "avg"})  # rename mean to avg
+
     return trend

--- a/backend/services/filters.py
+++ b/backend/services/filters.py
@@ -1,19 +1,83 @@
-import pandas as pd
+"""
+filters.py
+
+Database query functions for filtering water quality data.
+All filtering logic lives here — routes call these functions
+rather than querying the database directly.
+
+Persona coverage:
+    - Jack Wilshere: date range and site filtering directly implements
+      his US-02 acceptance criteria for focused dataset analysis
+
+    - George Weah: filtering by site and date enables historical trend
+      comparison for contamination risk assessment (US-10)
+
+    - Lebo Xhosa: site filtering retrieves his specific water sources
+      for the binary status dashboard (US-07)
+"""
+
+from database.database import SessionLocal
+from database.models import Site, WaterReading
+
+
+def get_site_by_code(db: SessionLocal, site_code: str) -> Site | None:
+    """
+    Looks up a site by its site_code string.
+
+    Arguments:
+    - db: Active SQLAlchemy databasee session.
+    - site_code: The site identifier string from the request parameters.
+
+    Returns:
+    - The matching Site object or None if not founnd.
+    """
+
+    return db.query(Site).filter(Site.site_code == site_code).first()
+
+
+def get_valid_site_codes(db: SessionLocal) -> list:
+    """
+    Returns a list of all valid site code strings.
+
+    Arguments:
+    - db: Active SQLAlchemy database sessionn.
+
+
+    Returns:
+    -  Alist of site_code strings for all sites.
+    """
+
+    sites = db.query(Site.site_code).all()
+    return [site.site_code for site in sites]
 
 
 def filter_water_data(
-    site_id, start_date=None, end_date=None
-):  # function that filters water data by site and date range(if specified) and returns a filtered dataframe
-    data = df[df["site_id"] == site_id].copy()  # selects rows that pertain to the chosen site_id
+    db: SessionLocal, site_code: str, start_date: str | None = None, end_date: str | None = None
+):
+    """
+    Filters water readings by the site and optional date range.
+
+    Argumennts:
+        - db: Active SQLAlchemy database session.
+        - site_code: The site identifier string (e.g. "site_upstream")
+        - start_date: Optional ISO 8601 date string
+        - end_date Optionnal ISO 8601 date string
+
+    Returns:
+        - A SQLAlchemy query of WaterREading rows that are ordered by recorded_at,
+         or None if the site_code doesn't exist.
+    """
+    site = get_site_by_code(db, site_code)
+
+    if site is None:
+        return None
+
+    query = db.query(WaterReading.site_id == site.id)
 
     if start_date:
-        data = data[
-            data["timestamp"] >= pd.to_datetime(start_date)
-        ]  # if start date is specified - filter rows after given start date
+        query = query.filter(WaterReading.recorded_at >= start_date)
 
     if end_date:
-        data = data[
-            data["timestamp"] <= pd.to_datetime(end_date)
-        ]  # if end date is specified - filter rows before given end date
+        query = query.filter(WaterReading.recorded_at <= end_date)
 
-    return data  # return a filtered data frame
+    return query.order_by(WaterReading.recorded_at)

--- a/backend/tests/test_timeseries.py
+++ b/backend/tests/test_timeseries.py
@@ -1,0 +1,233 @@
+"""
+test_timeseries.py
+
+Unit tests for GET /timeseries endpoint.
+Tests aggregated water quality readings over time for a site and metric.
+Persona coverage:
+
+    - Jack Wilshere: trend analysis across date ranges and sites (US-03)
+
+    - George Weah: historical comparison for contamination detection (US-10)
+"""
+
+import pytest
+from datetime import datetime
+
+from app import app
+from database.database import Base, SessionLocal, engine
+from database.models import Site, WaterReading
+
+
+@pytest.fixture
+def client():
+    """This creates a test Flask client with a fresh test database."""
+    app.config["TESTING"] = True
+    Base.metadata.create_all(bind=engine)
+
+    db = SessionLocal()
+
+    site = Site(
+        site_code="site_test",
+        name="Test Site",
+        description="Test site for unit tests",
+        is_active=True,
+    )
+    db.add(site)
+    db.commit()
+    db.refresh(site)
+
+    # add readings across two days for aggregation testing
+    readings = [
+        WaterReading(
+            site_id=site.id,
+            recorded_at=datetime(2023, 1, 1, 6, 0, 0),
+            ph=7.0,
+            turbidity_ntu=2.0,
+            conductivity_uS_cm=300.0,
+            water_temperature_c=15.0,
+            water_level_cm=100.0,
+            light_lux=500.0,
+            status="normal",
+            alert_triggered=False,
+            alert_ph=False,
+            alert_turbidity=False,
+            alert_turbidity_crit=False,
+            alert_conductivity=False,
+            sensor_fault=False,
+        ),
+        WaterReading(
+            site_id=site.id,
+            recorded_at=datetime(2023, 1, 1, 12, 0, 0),
+            ph=7.4,
+            turbidity_ntu=3.0,
+            conductivity_uS_cm=350.0,
+            water_temperature_c=17.0,
+            water_level_cm=110.0,
+            light_lux=800.0,
+            status="normal",
+            alert_triggered=False,
+            alert_ph=False,
+            alert_turbidity=False,
+            alert_turbidity_crit=False,
+            alert_conductivity=False,
+            sensor_fault=False,
+        ),
+        WaterReading(
+            site_id=site.id,
+            recorded_at=datetime(2023, 1, 2, 6, 0, 0),
+            ph=6.8,
+            turbidity_ntu=4.0,
+            conductivity_uS_cm=400.0,
+            water_temperature_c=14.0,
+            water_level_cm=105.0,
+            light_lux=400.0,
+            status="normal",
+            alert_triggered=False,
+            alert_ph=False,
+            alert_turbidity=False,
+            alert_turbidity_crit=False,
+            alert_conductivity=False,
+            sensor_fault=False,
+        ),
+        # sensor fault row — should be excluded from aggregation
+        WaterReading(
+            site_id=site.id,
+            recorded_at=datetime(2023, 1, 2, 12, 0, 0),
+            ph=99.0,
+            turbidity_ntu=5.0,
+            conductivity_uS_cm=450.0,
+            water_temperature_c=16.0,
+            water_level_cm=108.0,
+            light_lux=600.0,
+            status="warning",
+            alert_triggered=True,
+            alert_ph=False,
+            alert_turbidity=False,
+            alert_turbidity_crit=False,
+            alert_conductivity=False,
+            sensor_fault=True,
+            fault_reason="pH outside possible range 0-14",
+        ),
+    ]
+
+    for reading in readings:
+        db.add(reading)
+    db.commit()
+    db.close()
+
+    with app.test_client() as client:
+        yield client
+
+    Base.metadata.drop_all(bind=engine)
+
+
+def test_timeseries_returns_200(client):
+    """The GET/timeseries endpoint with valid paramaterss should return HTTP 200."""
+    response = client.get("/timeseries?site_code=site_test&metric=ph&freq=D")
+    assert response.status_code == 200
+
+
+def test_timeseries_returns_list(client):
+    """The GET/timeseries enndpoint should return a JSON array."""
+    response = client.get("/timeseries?site_code=site_test&metric=ph&freq=D")
+    data = response.get_json()
+    assert isinstance(data, list)
+
+
+def test_timeseries_returns_correct_fields(client):
+    """The GET/timeseries endppoint should return recorded_at, avg, min and max per bucket."""
+    response = client.get("/timeseries?site_code=site_test&metric=ph&freq=D")
+    data = response.get_json()
+    assert len(data) > 0
+    first = data[0]
+    assert "recorded_at" in first
+    assert "avg" in first
+    assert "min" in first
+    assert "max" in first
+
+
+def test_timeseries_daily_aggregation(client):
+    """The GET/timeseries endpoint with freq=D should return one row per day."""
+    response = client.get("/timeseries?site_code=site_test&metric=ph&freq=D")
+    data = response.get_json()
+    # two days of data — expect 2 rows
+    assert len(data) == 2
+
+
+def test_timeseries_hourly_aggregation(client):
+    """The GET/timeseries endpoinnt with freq=h should return one row per hour."""
+    response = client.get("/timeseries?site_code=site_test&metric=ph&freq=h")
+    data = response.get_json()
+    # 3 valid readings at different hours (fault row excluded) — expect 3 rows
+    assert len(data) == 3
+
+
+def test_timeseries_excludes_sensor_fault_rows(client):
+    """The GET/timeseries endpont should exclude sensor fault rows from aggregation.
+
+    The fixture includes a fault row with ph=99.0 on 2023-01-02.
+    The daily average for that day should only reflect the valid reading
+    (ph=6.8) not the faulty one.
+    """
+    response = client.get("/timeseries?site_code=site_test&metric=ph&freq=D")
+    data = response.get_json()
+    day_two = next(r for r in data if "2023-01-02" in r["recorded_at"])
+    assert day_two["avg"] == pytest.approx(6.8, abs=0.01)
+    assert day_two["max"] == pytest.approx(6.8, abs=0.01)
+
+
+def test_timeseries_default_metric_is_ph(client):
+    """GET/timeseries endpoint without metric param should default to ph."""
+    response = client.get("/timeseries?site_code=site_test&freq=D")
+    assert response.status_code == 200
+
+
+def test_timeseries_default_freq_is_daily(client):
+    """The GET/timeseries enndpoint without freq param should default to daily."""
+    response = client.get("/timeseries?site_code=site_test&metric=ph")
+    data = response.get_json()
+    assert response.status_code == 200
+    assert len(data) == 2
+
+
+def test_timeseries_date_range_filter(client):
+    """GET/timeseries endpoint with start and end should return only data in range."""
+    response = client.get(
+        "/timeseries?site_code=site_test&metric=ph&freq=D&start=2023-01-01&end=2023-01-02"
+    )
+    data = response.get_json()
+    assert response.status_code == 200
+    assert len(data) == 1
+    assert "2023-01-01" in data[0]["recorded_at"]
+
+
+def test_timeseries_missing_site_code_returns_400(client):
+    """GET/timeseries endpoint without site_code should return HTTP 400."""
+    response = client.get("/timeseries?metric=ph&freq=D")
+    assert response.status_code == 400
+
+
+def test_timeseries_invalid_site_code_returns_400(client):
+    """GET/timeseries endpoint with invalid site_code should return HTTP 400."""
+    response = client.get("/timeseries?site_code=fake_site&metric=ph")
+    assert response.status_code == 400
+
+
+def test_timeseries_invalid_metric_returns_400(client):
+    """GET/timeseries ennndpoint with invalid metric should return HTTP 400."""
+    response = client.get("/timeseries?site_code=site_test&metric=invalid_col")
+    assert response.status_code == 400
+
+
+def test_timeseries_invalid_freq_returns_400(client):
+    """GET/timeseries endpoint  with invalid frequency should return HTTP 400."""
+    response = client.get("/timeseries?site_code=site_test&metric=ph&freq=weekly")
+    assert response.status_code == 400
+
+
+def test_timeseries_no_data_in_range_returns_404(client):
+    """GET/timeseries endpoint with date range outside data should return HTTP 404."""
+    response = client.get(
+        "/timeseries?site_code=site_test&metric=ph&freq=D&start=2099-01-01&end=2099-12-31"
+    )
+    assert response.status_code == 404


### PR DESCRIPTION
Implements the GET /timeseries endpoint in routes/timeseries.py and 
the aggregation service in services/aggregation.py.

The timeseries endpoint returns water quality readings aggregated 
into daily or hourly buckets for a given site and metric. It 
supports optional date range filtering and defaults to daily 
aggregation of pH if no parameters are specified.

The aggregation service uses a hybrid approach — SQLAlchemy for 
database querying and filtering, pandas for resampling. Sensor 
fault rows are excluded from aggregation so faulty readings do 
not skew averages or trend charts.

## Closes
Closes #11

## Persona served
- Jack Wilshere: primary use case — GET /timeseries directly 
  implements his US-03 trend chart story. Supports hourly and 
  daily aggregation so he can choose the resolution appropriate 
  for his research. Date range filtering lets him focus on 
  specific periods of interest without downloading the full dataset
- George Weah: compares current readings against historical trends 
  to determine whether a contamination indicator is a short-term 
  fluctuation or a developing public health risk (US-10)

## Changes made
- Added routes/timeseries.py — GET /timeseries endpoint with 
  inline validation for site_code, metric, and frequency
- Added services/aggregation.py — get_trends() function using 
  SQLAlchemy queries loaded into pandas for resampling
- Added tests/test_timeseries.py — 14 unit tests
- Sensor fault rows excluded from aggregation via 
  sensor_fault == False filter
- NaN rows dropped after resampling so empty time buckets 
  are not returned

## Design decisions
The hybrid SQLAlchemy + pandas approach was chosen because 
SQLAlchemy handles large dataset filtering efficiently via 
indexed queries, while pandas resample() provides clean 
aggregation without reimplementing time bucketing logic. 
Loading only the filtered rows into pandas keeps memory 
usage manageable even for long date ranges.

Sensor fault rows are excluded at the query level rather than 
after loading into pandas — this means faulty data never enters 
the aggregation pipeline, protecting the integrity of Jack's 
research outputs and George's contamination trend analysis.

### Unit tests
pytest tests/test_timeseries.py -v — 14/14 passing

| Test | Result |
|---|---|
| test_timeseries_returns_200 | ✅ Pass |
| test_timeseries_returns_list | ✅ Pass |
| test_timeseries_returns_correct_fields | ✅ Pass |
| test_timeseries_daily_aggregation | ✅ Pass |
| test_timeseries_hourly_aggregation | ✅ Pass |
| test_timeseries_excludes_sensor_fault_rows | ✅ Pass |
| test_timeseries_default_metric_is_ph | ✅ Pass |
| test_timeseries_default_freq_is_daily | ✅ Pass |
| test_timeseries_date_range_filter | ✅ Pass |
| test_timeseries_missing_site_code_returns_400 | ✅ Pass |
| test_timeseries_invalid_site_code_returns_400 | ✅ Pass |
| test_timeseries_invalid_metric_returns_400 | ✅ Pass |
| test_timeseries_invalid_freq_returns_400 | ✅ Pass |
| test_timeseries_no_data_in_range_returns_404 | ✅ Pass |

closes #11 