### PR TITLE
Backend 48 ci testing

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,29 @@
+name: Backend CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          cd backend
+          pip install -r requirements.txt
+          pip install -r requirements_dev.txt
+
+      - name: Run backend tests
+        run: |
+          cd backend
+          pytest tests -v

--- a/backend/app.py
+++ b/backend/app.py
@@ -10,13 +10,14 @@ from flask import Flask
 
 from routes.sites import sites_bp
 
-# from routes.latest import latest_bp
+from routes.latest import latest_bp
 
-# from routes.summary import summary_bp
+from routes.summary import summary_bp
 
 from routes.timeseries import timeseries_bp
 
-# from routes.alerts import alerts_bp
+from routes.alerts import alerts_bp
+
 # from routes.export import export_bp
 
 from flask_cors import CORS
@@ -24,12 +25,12 @@ from flask_cors import CORS
 app = Flask(__name__)
 CORS(app)
 app.register_blueprint(sites_bp)
-# app.register_blueprint(latest_bp)
-# app.register_blueprint(summary_bp)
+app.register_blueprint(latest_bp)
+app.register_blueprint(summary_bp)
 
 app.register_blueprint(timeseries_bp)
 
-# pp.register_blueprint(alerts_bp)
+app.register_blueprint(alerts_bp)
 # app.register_blueprint(export_bp)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added:
- Added GitHub Actions CI workflow for backend pytest tests
- Workflow now runs automatically on push and pull requests
- Fixed failing CI tests caused by /summary endpoint not being registered

Testing:
- Initial CI run failed because /summary returned 404
- Investigated and realised issues were coming from certain register blueprints being commented out in app.py, so undid that
- Re-ran pytest locally and through GitHub Actions
- All backend tests that have been added now passing

Checks will be double checked after requesting a pull request

closes #48