### PR TITLE
Backend feature issue 47 simulate streaming

### DIFF
--- a/backend/scripts/simulate_stream.py
+++ b/backend/scripts/simulate_stream.py
@@ -1,0 +1,97 @@
+"""
+simulate_stream.py
+
+Simulates a streaming sensor feed by importing water quality data
+in small batches with a delay between each batch.
+
+Persona coverage:
+    - Lebo Xhosa: simulates continuous monitoring where new readings
+      arrive every few minutes rather than a static dataset
+
+    - George Weah: simulates live contamination data arriving during
+      an active monitoring period
+"""
+
+import time
+import pandas as pd
+
+from config import CSV_PATH
+from database.database import Base, SessionLocal, engine
+from scripts.import_water import get_or_create_site, import_rows
+
+BATCH_SIZE = 100
+DELAY_SECONDS = 5
+
+
+def main():
+    """Simulates a streaming sensor feed from the water quality CSV."""
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+
+    try:
+        # create  or retrieve the monitoring sites.
+        site_upstream = get_or_create_site(
+            db,
+            "site_upstream",
+            "Upstream Site",
+            "Reference point above agricultural land",
+            -32.780,
+            26.840,
+        )
+        site_downstream = get_or_create_site(
+            db,
+            "site_downstream",
+            "Downstream Site",
+            "Below farming activity",
+            -32.785,
+            26.845,
+        )
+        site_reservoir = get_or_create_site(
+            db,
+            "site_reservoir",
+            "Reservoir Site",
+            "Community dam",
+            -32.790,
+            26.850,
+        )
+        db.commit()
+
+        # build a lookup disctionary so that import_rows()
+        # can map site_code strings to their integer database IDs
+
+        site_ids = {
+            "site_upstream": site_upstream.id,
+            "site_downstream": site_downstream.id,
+            "site_reservoir": site_reservoir.id,
+        }
+
+        # load the full CSV into memory
+        # dropna removes the rows with missing timestamps
+        # drop_duplicates prevents importing the same reading twice
+        df = pd.read_csv(CSV_PATH, parse_dates=["timestamp"])
+        df = df.dropna(subset=["timestamp"])
+        df = df.drop_duplicates(subset=["site_id", "timestamp"], keep="first")
+
+        total = len(df)
+
+        # process the DataFrame in batches,
+        #  each iteration simulates one burst of sensor data arriving
+        for start in range(0, total, BATCH_SIZE):
+            batch = df.iloc[start : start + BATCH_SIZE]
+            import_rows(db, batch, site_ids)
+            end = min(start + BATCH_SIZE, total)
+            print(f"Imported rows {start} to {end} of {total}")
+            # wait before the next batch to simulate real sensor timing
+            #  then skip the delay after the final batch
+            if end < total:
+                time.sleep(DELAY_SECONDS)
+
+        print("Stream simulation complete.")
+
+    finally:
+        # close db session
+        db.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds scripts/simulate_stream.py which simulates a real-time 
streaming sensor feed by importing water quality data in batches 
of 100 rows every 5 seconds, mimicking how IoT field sensors 
would transmit readings continuously rather than as a bulk upload.

Also extracts import_rows() as a standalone reusable function in 
import_water.py so it can be called by both the bulk import script 
and the streaming simulation without duplicating logic. main() in 
import_water.py is unchanged.

## Closes
Closes #47  (create issue: "Add streaming simulation script")

## Persona served
- Lebo Xhosa: simulates the continuous monitoring environment 
  his farm sensors would produce — new readings arriving every 
  few minutes rather than a static dataset. Allows testing that 
  his dashboard updates with fresh data in near real-time
- George Weah: simulates live contamination data arriving during 
  an active monitoring period so the alerts endpoint can be tested 
  with data that arrives incrementally rather than all at once

## Changes made
- Added scripts/simulate_stream.py — streams CSV data in batches 
  with configurable BATCH_SIZE and DELAY_SECONDS constants
- Extracted import_rows(db, df_batch, site_ids) from import_water.py 
  — reusable function that processes a DataFrame batch with full 
  validation and alert event creation
- Added KeyboardInterrupt handler for clean cancellation
- Google-style docstrings and inline comments throughout

## Design decision
import_water.py main() was deliberately kept unchanged. The 
import_rows() function was extracted as an addition rather than 
a refactor so the existing bulk import workflow is not affected. 
The streaming script manages its own database session and site 
lookups independently.

## How I tested it

### Manual testing
- python -m scripts.simulate_stream ran correctly and printed 
  batch progress every 5 seconds